### PR TITLE
Django Take-Home Assessment - Adding Custom Template Filters

### DIFF
--- a/l2l/templates/l2l/index.html
+++ b/l2l/templates/l2l/index.html
@@ -1,5 +1,5 @@
 {% load static %}
-{#{% load l2l_extras %}#}
+{% load l2l_extras %}
 <!doctype html>
 <html lang="en">
     <head>
@@ -57,8 +57,8 @@
           <p class="lead fw-normal">Yes this is a rip-off from one of Bootstrap's example html pages.</p>
           <p class="lead fw-normal">Today's date is: {{ now }}</p>
           <p class="lead fw-normal">Today's ISO date is: {{ iso }}</p>
-          {#<p class="lead fw-normal">Today's date from a date is: {{ now|l2l_dt }}</p>#}
-          {#<p class="lead fw-normal">Today's date from a string is: {{ iso|l2l_dt }}</p>#}
+          <p class="lead fw-normal">Today's date from a date is: {{ now|l2l_dt }}</p>
+          <p class="lead fw-normal">Today's date from a string is: {{ iso|l2l_dt }}</p>
           <a class="btn btn-outline-secondary" href="#">Coming soon</a>
         </div>
         <div class="product-device shadow-sm d-none d-md-block"></div>

--- a/l2l/templatetags/l2l_extras.py
+++ b/l2l/templatetags/l2l_extras.py
@@ -6,8 +6,13 @@ from django import template
 register = template.Library()
 
 def l2l_dt(value):
+    # Expecting datetime or str, else raise TypeError
     if isinstance(value, str):
         value = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+    elif isinstance(value, datetime):
+        pass
+    else:
+        raise TypeError(f'Unexpected type. Expected datetime or str, instead got {type(value)}')
     
     return value.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/l2l/templatetags/l2l_extras.py
+++ b/l2l/templatetags/l2l_extras.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from django import template
+
+
+register = template.Library()
+
+def l2l_dt(value):
+    if isinstance(value, str):
+        value = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+    
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+register.filter('l2l_dt', l2l_dt)


### PR DESCRIPTION
- added custom template filter - `l2l_dt` inside new directory `l2l_extras`
- new filter takes a `str` or a `datetime` object and returns a formatted string: `%Y-%m-%d %H:%M:%S`, raises `TypeError` if arg is not one of the two types expected